### PR TITLE
New feature to support offline install

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,5 @@ skip_list:
   - name[template]
   - schema[meta]
   - yaml[line-length]
+  - fqcn[action-core]
+  - fqcn[action]

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ __pycache__
 
 # Offline test #
 ################
-./offline
+offline/*
+!offline/pkg/.gitkeep
+!offline/nginx/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ __pycache__
 # Logs #
 ########
 *.log
+
+# Offline test #
+################
+./offline

--- a/defaults/main/custom-app.yml
+++ b/defaults/main/custom-app.yml
@@ -1,0 +1,13 @@
+---
+## If you set this variable to `true`. it mean you can customize setting for NGINX components.
+nginx_custom_app_enabled: false
+
+customize_owner_user: "{{ ansible_user }}"
+customize_owner_group: "{{ ansible_user }}"
+
+customize_base_path: "/app"
+customize_base_log_path: "{{ customize_base_path }}/nginx/log"
+customize_base_ssl_path: "{{ customize_base_path }}/nginx/ssl"
+# customize_base_pid_path: "{{ customize_base_path }}/nginx/run"
+customize_base_cache_path: "{{ customize_base_path }}/nginx/cache"
+# customize_file_pid_name: "nginx.pid"

--- a/defaults/main/logrotate.yml
+++ b/defaults/main/logrotate.yml
@@ -1,5 +1,6 @@
 ---
 # Create custom logrotate config
+nginx_logrotate_package: logrotate
 nginx_logrotate_conf_enable: false
 nginx_logrotate_conf:
   paths:

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -39,7 +39,7 @@ nginx_manage_repo: true
 
 # Specify repository origin for NGINX Open Source.
 # Only works if 'nginx_type' is set to 'opensource'.
-# Options are 'nginx_repository', 'source' or 'os_repository'.
+# Options are 'nginx_repository', 'source', 'offline_pkg' or 'os_repository'.
 # When using 'os_repository' on CentOS/RHEL 7 based systems, you will also need to install the EPEL repository (see the 'nginx_install_epel_release' variable below).
 # Default is nginx_repository.
 nginx_install_from: nginx_repository

--- a/defaults/main/offline.yml
+++ b/defaults/main/offline.yml
@@ -1,0 +1,11 @@
+---
+## This var file enable with set `nginx_install_from` to `offline_pkg`
+# If this option set to `true`, It will disable install from internet and lookup offline packages.
+nginx_offline_installed: false
+
+# This value is provide a base location you store the package files.
+# It will copy all file under this folder to target host before install it.
+nginx_offline_dependencies_basepath: "{{ playbook_dir }}/files/{{ group_names[0] }}/pkg/"
+nginx_offline_main_basepath: "{{ playbook_dir }}/files/{{ group_names[0] }}/nginx/"
+nginx_offline_dependencies_target_path: "/tmp/capco_pkg/pkg/"
+nginx_offline_main_target_path: "/tmp/capco_pkg/nginx/"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,8 @@
 - name: (Handler) Systemd daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
+  become: true
+  become_user: root
 
 - name: (Handler) Start/reload NGINX
   ansible.builtin.service:
@@ -12,6 +14,8 @@
     - nginx_start | bool
     - nginx_state != 'absent'
     - not ansible_check_mode | bool
+  become: true
+  become_user: root
   listen: (Handler) Run NGINX
 
 - name: (Handler) Check NGINX
@@ -23,6 +27,8 @@
   ignore_errors: true
   check_mode: false
   changed_when: false
+  become: true
+  become_user: root
   when: nginx_state != 'absent'
   listen: (Handler) Run NGINX
 
@@ -49,6 +55,8 @@
   ignore_errors: true
   check_mode: false
   changed_when: false
+  become: true
+  become_user: root
   listen: (Handler) Run logrotate
 
 - name: (Handler) Print logrotate error if config check fails

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,14 +1,12 @@
 ---
 galaxy_info:
-  author: nginxinc
+  author: Start
   description: Official Ansible role for installing NGINX
   role_name: nginx
-  company: F5, Inc.
-
+  namespace: capcoth
+  company: Capco consultancy
   license: Apache License, Version 2.0
-
-  min_ansible_version: '2.12'
-
+  min_ansible_version: '2.9'
   platforms:
     - name: Alpine
       versions: [all]
@@ -19,14 +17,13 @@ galaxy_info:
     - name: EL
       versions: ['7', '8', '9']
     - name: FreeBSD
-      versions: ['12.1', '12.2', '12.3', '12.4', '13.0', '13.1', '13.2']
+      versions: ['12.1', '12.2', '13.0', '13.1', '13.2']
     - name: OracleLinux
-      versions: ['7', '8', '9']
+      versions: ['all']
     - name: Ubuntu
-      versions: [focal, jammy, kinetic, lunar]
+      versions: [focal, jammy]
     - name: SLES
       versions: ['12', '15']
-
   galaxy_tags:
     - nginx
     - oss
@@ -37,7 +34,7 @@ galaxy_info:
     - development
     - install
 
-collections:
-  - ansible.posix
-  - community.crypto
-  - community.general
+# collections:
+#   - ansible.posix
+#   - community.crypto
+#   - community.general

--- a/molecule/azure/converge.yml
+++ b/molecule/azure/converge.yml
@@ -1,0 +1,38 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    # nginx_modules:
+    #   - geoip
+    #   - image-filter
+    #   - njs
+    #   - perl
+    #   - xslt
+    nginx_offline_installed: true
+    nginx_custom_app_enabled: true
+    nginx_install_from: 'offline_pkg'
+    nginx_offline_dependencies_basepath: "{{ playbook_dir }}/../../offline/pkg/"
+    nginx_offline_main_basepath: "{{ playbook_dir }}/../../offline/nginx/"
+    nginx_service_modify: true
+    nginx_service_timeout: 95
+    nginx_logrotate_conf_enable: true
+    nginx_logrotate_conf:
+      paths:
+        - /app/nginx/log/*.log
+      options:
+        - daily
+        - missingok
+        - rotate 14
+        - compress
+        - delaycompress
+        - notifempty
+        - sharedscripts
+        - create 0644 capco-user capco-user
+  tasks:
+    - name: Debug starting state
+      debug:
+        msg: "Starting molecule test...."
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx

--- a/molecule/azure/molecule.yml
+++ b/molecule/azure/molecule.yml
@@ -1,0 +1,34 @@
+---
+role_name_check: 1
+driver:
+  name: default
+platforms:
+  - name: instance
+    group:
+      - az_test
+    managed: false
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      instance:
+        ansible_host: 4.194.50.52
+        ansible_port: 22
+        ansible_user: 'capco-user'
+        ansible_ssh_private_key_file: /Users/wywt/Documents/Projects/BBL/ssh-key/api.pem
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+verifier:
+  name: ansible
+scenario:
+  name: azure
+  converge_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/azure/verify.yml
+++ b/molecule/azure/verify.yml
@@ -1,0 +1,44 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  vars:
+    nginx_dep_pkg:
+      - ca-certificates
+      - curl
+      - gnupg2
+      - nginx
+  tasks:
+    - name: Check if NGINX is installed
+      ansible.builtin.package:
+        name: "{{ nginx_dep_pkg }}"
+        state: present
+      check_mode: true
+      register: install
+      become: true
+      become_user: root
+      failed_when: (install is changed) or (install is failed)
+
+    - name: Check if NGINX service is running
+      ansible.builtin.service:
+        name: nginx
+        state: started
+        enabled: true
+      check_mode: true
+      register: service
+      become: true
+      become_user: root
+      failed_when: (service is changed) or (service is failed)
+
+    - name: Verify NGINX is up and running
+      ansible.builtin.uri:
+        url: http://localhost
+        status_code: 200
+
+    - name: Verify correct version of NGINX has been installed
+      ansible.builtin.command: nginx -v
+      args:
+        chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
+      changed_when: false
+      register: version
+      failed_when: version is not search('nginx')

--- a/molecule/offline/converge.yml
+++ b/molecule/offline/converge.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    # nginx_modules:
+    #   - geoip
+    #   - image-filter
+    #   - njs
+    #   - perl
+    #   - xslt
+    nginx_offline_installed: true
+    nginx_install_from: 'offline_pkg'
+    nginx_offline_dependencies_basepath: "{{ playbook_dir }}/../../offline/pkg/"
+    nginx_service_modify: true
+    nginx_service_timeout: 95
+    nginx_logrotate_conf_enable: true
+    nginx_logrotate_conf:
+      paths:
+        - /var/log/nginx/*.log
+      options:
+        - daily
+        - missingok
+        - rotate 14
+        - compress
+        - delaycompress
+        - notifempty
+        - sharedscripts
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx

--- a/molecule/offline/molecule.yml
+++ b/molecule/offline/molecule.yml
@@ -1,0 +1,30 @@
+---
+role_name_check: 1
+driver:
+  name: docker
+platforms:
+  - name: rhel-8
+    image: redhat/ubi8:8.9
+    # # platform: s390x
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: rhel-9
+    image: redhat/ubi9:9.1.0
+    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+provisioner:
+  name: ansible
+  log: true
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+  

--- a/molecule/offline/verify.yml
+++ b/molecule/offline/verify.yml
@@ -1,0 +1,39 @@
+---
+- name: Verify
+  hosts: all
+  vars:
+    nginx_dep_pkg:
+      - ca-certificates
+      - curl
+      - gnupg2
+      - nginx
+  tasks:
+    - name: Check if NGINX is installed
+      ansible.builtin.package:
+        name: "{{ nginx_dep_pkg }}"
+        state: present
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)
+
+    - name: Check if NGINX service is running
+      ansible.builtin.service:
+        name: nginx
+        state: started
+        enabled: true
+      check_mode: true
+      register: service
+      failed_when: (service is changed) or (service is failed)
+
+    - name: Verify NGINX is up and running
+      ansible.builtin.uri:
+        url: http://localhost
+        status_code: 200
+
+    - name: Verify correct version of NGINX has been installed
+      ansible.builtin.command: nginx -v
+      args:
+        chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
+      changed_when: false
+      register: version
+      failed_when: version is not search('1.25.1')

--- a/tasks/config/custom-app-path.yml
+++ b/tasks/config/custom-app-path.yml
@@ -1,0 +1,92 @@
+---
+- name: Got configure files in main path.
+  ansible.builtin.find:
+    path: "/etc/nginx"
+    file_type: any
+    recurse: true
+  register: nginx_dir_content
+  when: nginx_custom_app_enabled
+
+- name: Recursively change ownership.
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  with_items: "{{ nginx_dir_content.files }}"
+  become: true
+  become_user: root
+  when: nginx_dir_content is defined
+
+- name: Ensure custom base path provided.
+  ansible.builtin.file:
+    path: "{{ customize_base_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when: customize_base_path is defined
+
+- name: Ensure custom log path provided
+  ansible.builtin.file:
+    path: "{{ customize_base_cache_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when: customize_base_cache_path is defined
+
+- name: Ensure custom log path provided
+  ansible.builtin.file:
+    path: "{{ customize_base_log_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when: customize_base_log_path is defined
+
+- name: Ensure custom ssl path provided
+  ansible.builtin.file:
+    path: "{{ customize_base_ssl_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when: customize_base_ssl_path is defined
+
+- name: Ensure custom pid path provided
+  ansible.builtin.file:
+    path: "{{ customize_base_pid_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when: customize_base_pid_path is defined
+
+- name: Got pid file stat.
+  ansible.builtin.stat:
+    path: "{{ customize_base_pid_path }}/{{ customize_file_pid_name }}"
+  register: pid_file
+  when:
+    - customize_base_pid_path is defined
+    - customize_file_pid_name is defined
+
+- name: Ensure custom pid file provided.
+  ansible.builtin.file:
+    path: "{{ customize_base_pid_path }}/{{ customize_file_pid_name }}"
+    mode: '0644'
+    state: 'touch'
+    owner: "{{ customize_owner_user }}"
+    group: "{{ customize_owner_group }}"
+  when:
+    - pid_file.stat.exists is defined
+    - not pid_file.stat.exists
+
+- name: Apply custom main configure
+  ansible.builtin.template:
+    src: conf/nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+    mode: "0644"
+  become: true
+  become_user: root
+  notify: (Handler) Run NGINX
+  when: nginx_custom_app_enabled

--- a/tasks/config/modify-systemd.yml
+++ b/tasks/config/modify-systemd.yml
@@ -4,6 +4,9 @@
     path: "{{ nginx_service_overridepath }}"
     state: directory
     mode: "0755"
+    owner: root
+  become: true
+  become_user: root
 
 - name: Create override for NGINX systemd service
   ansible.builtin.template:
@@ -15,6 +18,8 @@
   when:
     - not nginx_service_custom | bool
     - not nginx_service_clean | bool
+  become: true
+  become_user: root
   notify: (Handler) Systemd daemon-reload
 
 - name: Customize override for NGINX systemd service
@@ -27,6 +32,8 @@
   when:
     - nginx_service_custom | bool
     - not nginx_service_clean | bool
+  become: true
+  become_user: root
   notify: (Handler) Systemd daemon-reload
 
 - name: Remove override for NGINX systemd service

--- a/tasks/config/setup-logrotate.yml
+++ b/tasks/config/setup-logrotate.yml
@@ -1,30 +1,40 @@
 ---
 - name: (Alpine Linux) Install logrotate
   community.general.apk:
-    name: logrotate
+    name: "{{ nginx_logrotate_package }}"
   when: ansible_facts['os_family'] == 'Alpine'
+  become: true
+  become_user: root
 
 - name: (Debian/Ubuntu) Install logrotate
   ansible.builtin.apt:
-    name: logrotate
+    name: "{{ nginx_logrotate_package }}"
     state: present
   when: ansible_facts['os_family'] == 'Debian'
+  become: true
+  become_user: root
 
 - name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install logrotate
   ansible.builtin.yum:
-    name: logrotate
+    name: "{{ nginx_logrotate_package }}"
     state: present
   when: ansible_facts['os_family'] == 'RedHat'
+  become: true
+  become_user: root
 
 - name: (SLES) Install Logrotate
   community.general.zypper:
-    name: logrotate
+    name: "{{ nginx_logrotate_package }}"
     state: present
   when: ansible_facts['os_family'] == 'Suse'
+  become: true
+  become_user: root
 
 - name: Create logrotate config
   ansible.builtin.template:
     src: logrotate/nginx.j2
     dest: /etc/logrotate.d/nginx
     mode: "0644"
+  become: true
+  become_user: root
   notify: (Handler) Run logrotate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Set up signing keys
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/keys/setup-keys.yml"
-  when: (nginx_enable | bool and nginx_install_from == 'nginx_repository')
+  when: (nginx_enable | bool and nginx_install_from == 'nginx_repository' and not nginx_offline_installed)
         or nginx_amplify_enable | bool
   tags: nginx_key
 
@@ -48,6 +48,11 @@
         - nginx_type == 'plus'
         - nginx_remove_license | bool
       tags: nginx_remove_license
+    
+    - name: Modify NGINX paths
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/config/custom-app-path.yml"
+      when: nginx_custom_app_enabled | bool
+      tags: nginx_paths_customize
 
     - name: Modify systemd parameters
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/config/modify-systemd.yml"

--- a/tasks/opensource/install-offline.yml
+++ b/tasks/opensource/install-offline.yml
@@ -1,0 +1,42 @@
+---
+- name: Ensure tmp folder {{ nginx_offline_main_target_path }} is exists
+  ansible.builtin.file:
+    path: "{{ nginx_offline_main_target_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+
+- name: Copy package files into host
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ nginx_offline_main_target_path }}"
+    mode: '0744'
+    owner: "{{ ansible_user }}"
+  with_fileglob:
+    - "{{ nginx_offline_main_basepath }}/*.rpm"
+  register: nginx_copied
+
+- name: Get files in target folder
+  ansible.builtin.find:
+    paths: "{{ nginx_offline_main_target_path }}"
+    file_type: "file"
+    patterns: "*.rpm"
+  register: rpm_nginx_files
+
+- name: Define list of rpm files to install from local
+  ansible.builtin.set_fact:
+    rpm_nginx_path_install: "{{ rpm_nginx_files.files | map(attribute='path') | list }}"
+
+- name: Printout rpm_nginx_files
+  ansible.builtin.debug:
+    var: rpm_nginx_path_install
+
+- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install NGINX local packages.
+  ansible.builtin.yum:
+    name: "{{ rpm_nginx_path_install }}"
+    update_cache: false
+    state: present # noqa package-latest
+  when: ansible_facts['os_family'] == 'RedHat'
+  become: true
+  become_user: root
+  notify: (Handler) Run NGINX

--- a/tasks/opensource/install-oss.yml
+++ b/tasks/opensource/install-oss.yml
@@ -13,6 +13,10 @@
     - name: "{{ nginx_setup | capitalize }} NGINX from source"
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/opensource/install-source.yml"
       when: nginx_install_from == 'source'
+    
+    - name: "{{ nginx_setup | capitalize }} NGINX from local package"
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/opensource/install-offline.yml"
+      when: nginx_install_from == 'offline_pkg'
 
 - name: "{{ nginx_setup | capitalize }} NGINX in Unix systems"
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/opensource/install-bsd.yml"

--- a/tasks/prerequisites/offline-dependencies.yml
+++ b/tasks/prerequisites/offline-dependencies.yml
@@ -1,0 +1,41 @@
+---
+- name: Ensure tmp folder {{ nginx_offline_dependencies_target_path }} is exists
+  ansible.builtin.file:
+    path: "{{ nginx_offline_dependencies_target_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+
+- name: Copy package files into host
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ nginx_offline_dependencies_target_path }}"
+    mode: '0744'
+    owner: "{{ ansible_user }}"
+  with_fileglob:
+    - "{{ nginx_offline_dependencies_basepath }}/*.rpm"
+  register: pkg_copied
+
+- name: Get files in target folder
+  ansible.builtin.find:
+    paths: "{{ nginx_offline_dependencies_target_path }}"
+    file_type: "file"
+    patterns: "*.rpm"
+  register: rpm_files
+
+- name: Define list of rpm files to install from local
+  ansible.builtin.set_fact:
+    rpm_path_install: "{{ rpm_files.files | map(attribute='path') | list }}"
+
+- name: Printout rpm_files
+  ansible.builtin.debug:
+    var: rpm_path_install
+
+- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install dependencies
+  ansible.builtin.yum:
+    name: "{{ rpm_path_install }}"
+    update_cache: false
+    state: present # noqa package-latest
+  when: ansible_facts['os_family'] == 'RedHat'
+  become: true
+  become_user: root

--- a/tasks/prerequisites/prerequisites.yml
+++ b/tasks/prerequisites/prerequisites.yml
@@ -1,6 +1,13 @@
 ---
 - name: Install dependencies
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/prerequisites/install-dependencies.yml"
+  when:
+    - not nginx_offline_installed
+
+- name: Install dependencies offline
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/prerequisites/offline-dependencies.yml"
+  when:
+    - nginx_offline_installed
 
 - name: Set up SELinux
   when:

--- a/templates/conf/nginx.conf.j2
+++ b/templates/conf/nginx.conf.j2
@@ -1,0 +1,35 @@
+user  {{ customize_owner_user }};
+worker_processes  auto;
+
+error_log  {{ customize_base_log_path }}/error.log notice;
+{% if customize_base_pid_path is defined %}
+pid        {{ customize_base_pid_path }}/{{ customize_file_pid_name }};
+{% else %}
+pid        /var/run/nginx.pid;
+{% endif %}
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  {{ customize_base_log_path }}/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 # Set the values allowed for various variables
 nginx_setup_vars: [install, uninstall, upgrade]
 
-nginx_install_from_vars: [nginx_repository, source, os_repository]
+nginx_install_from_vars: [nginx_repository, source, os_repository, offline_pkg]
 
 nginx_branch_vars: [mainline, stable]
 


### PR DESCRIPTION
### Proposed changes

I have to expand a new feature for this playbook, which it can support install services from local package(also offline). So, it can move the customize logging and caching data path off default directory.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).

### Test scenario

You can use molecule's scenario named `azure` to verify this feature.